### PR TITLE
Change 'ClimateDevice' to 'ClimateEntity', add "version" to manifset.json, change cookie name due to error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This component is a fork from https://github.com/jamiewalters//python-verisure-climate. It seems like he is no longer active on this component, but there is an active pull-request waiting for him. For time beeing my version is the only active, and fully working, version of this custom component.
+This component is a fork from https://github.com/jamiewalters/python-verisure-climate. It seems like he is no longer active on this component, but there is an active pull-request waiting for him. For time beeing my version is the only active, and fully working, version of this custom component.
 
 # Access Verisure HeatPumps in HomeAssistant
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This component is a fork from https://github.com/jamiewalters//python-verisure-climate. It seems like he is no longer active on this component, but there is an active pull-request waiting for him. For time beeing my version is the only active, and fully working, version of this custom component.
+
 # Access Verisure HeatPumps in HomeAssistant
 
 After HA Climate 1.0-change refactoring work had to be done.

--- a/climate.py
+++ b/climate.py
@@ -5,7 +5,7 @@ import jsonpath
 import dateutil.parser
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.climate import (
-    ClimateDevice,
+    ClimateEntity,
     PLATFORM_SCHEMA)
 from homeassistant.components.climate.const import (
     HVAC_MODE_COOL,
@@ -100,7 +100,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         ])
 
 
-class HeatPump(ClimateDevice):
+class HeatPump(ClimateEntity):
     """Representation of a demo climate device."""
 
     def __init__(self, heatpumpid):
@@ -220,7 +220,6 @@ class HeatPump(ClimateDevice):
             self._on = True
         if hvac_mode == HVAC_MODE_OFF:
             session.set_heat_pump_power(self.id, 'OFF')
-            self._on = False
         else:
             session.set_heat_pump_mode(self.id,
                                        HA_STATE_TO_VERISURE[hvac_mode])

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
 "domain": "verisureclimate",
 "name": "Verisureclimate",
-"documentation": "https://github.com/jamiewalters/python-verisure-climate",
+"documentation": "https://github.com/mycortex/python-verisure-climate",
 "dependencies": [],
 "codeowners": [],
-"requirements": []
+"requirements": [],
+"version": "1.0.0"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 "domain": "verisureclimate",
 "name": "Verisureclimate",
-"documentation": "https://github.com/jamiewalters/python-verisure-climate",
+"documentation": "https://github.com/mycortex/python-verisure-climate",
 "dependencies": [],
 "codeowners": [],
 "requirements": [],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 "domain": "verisureclimate",
 "name": "Verisureclimate",
-"documentation": "https://github.com/mycortex/python-verisure-climate",
+"documentation": "https://github.com/jamiewalters/python-verisure-climate",
 "dependencies": [],
 "codeowners": [],
 "requirements": [],

--- a/verisure/session.py
+++ b/verisure/session.py
@@ -56,7 +56,7 @@ class Session(object):
     """
 
     def __init__(self, username, password,
-                 cookieFileName='~/.verisure-cookie'):
+                 cookieFileName='~/.verisure-cookie_1'):
         self._username = username
         self._password = password
         self._cookieFileName = os.path.expanduser(cookieFileName)
@@ -532,7 +532,7 @@ class Session(object):
     def set_heat_pump_mode(self, device_label, mode):
         """ Set heatpump mode
         Args:
-            mode (str): 'HEAT', 'COOL', 'FAN' or 'AUTO'
+            mode (str): 'heat', 'cool', 'fan' or 'auto'
         """
         response = None
         try:


### PR DESCRIPTION
This was creating errors in the log saying ClimateDevice HeatPump is deprecated.

This fix is to change 'ClimateDevice' to 'ClimateEntity'